### PR TITLE
Fix #45. In Polymer 2+ add-drawer needs a slot='drawer' attribute

### DIFF
--- a/src/quantum-app.html
+++ b/src/quantum-app.html
@@ -121,7 +121,7 @@
     <app-drawer-layout fullbleed force-narrow>
 
       <!-- Drawer content -->
-      <app-drawer>
+      <app-drawer slot="drawer">
 
         <app-toolbar>
           <paper-icon-button icon="arrow-back" drawer-toggle></paper-icon-button>


### PR DESCRIPTION
Fix #45. In Polymer 2+ add-drawer needs a slot='drawer' attribute, without it app-drawer won't open